### PR TITLE
fix duplicate keys in footer icons

### DIFF
--- a/src/components/footer-social-icons.js
+++ b/src/components/footer-social-icons.js
@@ -11,13 +11,13 @@ const FooterSocialIcons = () => {
 
       return (
         <a
-          key={social[name]}
+          key={name}
           href={getContactHref(name, social[name])}
           rel="noopener noreferrer"
           target="_blank"
         >
           <svg viewBox={contact.viewBox} className="footer-social-icon">
-          <title>{name}</title>
+            <title>{name}</title>
             <path d={contact.path} />
           </svg>
         </a>


### PR DESCRIPTION
I have the same username for a few different social media accounts, so I got the duplicate keys warning from React. Now the key is based on the social media site name, not the username. 